### PR TITLE
html.canvas should comply with clearScreenEveryFrame

### DIFF
--- a/src/main/kotlin/games/perses/game/Game.kt
+++ b/src/main/kotlin/games/perses/game/Game.kt
@@ -185,9 +185,9 @@ object Game {
         resize()
 
         if (!pause) {
-          html.canvas2d.clearRect(0.0, 0.0, view.width.toDouble(), view.height.toDouble())
-
           if (clearScreenEveryFrame) {
+            html.canvas2d.clearRect(0.0, 0.0, view.width.toDouble(), view.height.toDouble())
+
             gl().clearColor(clearRed, clearGreen, clearBlue, clearAlpha)
             gl().clear(WebGLRenderingContext.COLOR_BUFFER_BIT)
           }

--- a/src/main/kotlin/games/perses/game/Game.kt
+++ b/src/main/kotlin/games/perses/game/Game.kt
@@ -105,6 +105,7 @@ object Game {
   }
 
   fun gl() = html.webgl
+  fun htmlCanvas() = html.canvas2d
 
   fun resize() {
     val canvas = gl().canvas
@@ -122,14 +123,14 @@ object Game {
 
       view.updateView()
 
-      val textCanvas = html.canvas2d.canvas
+      val htmlCanvas = htmlCanvas().canvas
 
       // Make the canvas the same size
       canvas.width = view.width.toInt()
       canvas.height = view.height.toInt()
 
-      textCanvas.width = view.width.toInt()
-      textCanvas.height = view.height.toInt()
+      htmlCanvas.width = view.width.toInt()
+      htmlCanvas.height = view.height.toInt()
 
       gl().viewport(0, 0, view.width.toInt(), view.height.toInt())
 
@@ -141,7 +142,7 @@ object Game {
           "position: absolute; left: ${borderLeft}px; top: ${borderTop}px; z-index: 5; " +
               "width: ${view.windowWidth}px; height: ${view.windowHeight}px;"
       )
-      textCanvas.setAttribute(
+      htmlCanvas.setAttribute(
           "style",
           "position: absolute; left: ${borderLeft}px; top: ${borderTop}px; z-index: 10; " +
               "width: ${view.windowWidth}px; height: ${view.windowHeight}px;"
@@ -186,7 +187,7 @@ object Game {
 
         if (!pause) {
           if (clearScreenEveryFrame) {
-            html.canvas2d.clearRect(0.0, 0.0, view.width.toDouble(), view.height.toDouble())
+            htmlCanvas().clearRect(0.0, 0.0, view.width.toDouble(), view.height.toDouble())
 
             gl().clearColor(clearRed, clearGreen, clearBlue, clearAlpha)
             gl().clear(WebGLRenderingContext.COLOR_BUFFER_BIT)

--- a/src/main/kotlin/games/perses/text/Texts.kt
+++ b/src/main/kotlin/games/perses/text/Texts.kt
@@ -25,9 +25,9 @@ object Texts {
     }
     yy = Game.view.height - yy
 
-    Game.html.canvas2d.fillStyle = fillStyle
-    Game.html.canvas2d.font = font
-    Game.html.canvas2d.fillText(message, x.toDouble(), yy.toDouble())
+    Game.htmlCanvas().fillStyle = fillStyle
+    Game.htmlCanvas().font = font
+    Game.htmlCanvas().fillText(message, x.toDouble(), yy.toDouble())
   }
 
   fun drawLeftTop(


### PR DESCRIPTION
Hi!
Love your small engine!

While playing around with the html canvas i saw that it wasn't possible to turn off cleaning of image each frame. I think this should be possible. First commit fixes this.

A side effect is that text looks weird. This is because they are using the same html canvas. Not sure if this a problem. Added small refactoring to make html.canvas2d usages more clear. See second commit.

/Max