### PR TITLE
Fix for usage in multiplatform(webpack?) projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
 compileKotlin2Js {
     kotlinOptions.metaInfo = true
+    kotlinOptions.moduleKind = 'umd'
 
     compileKotlin2Js.kotlinOptions.sourceMap = true
     compileKotlin2Js.kotlinOptions.outputFile = "${buildDir}/kotlinjs/kudens.js"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'perses.games'
-version '1.1.7'
+version '1.1.8-SNAPSHOT'
 
 apply plugin: 'kotlin2js'
 apply plugin: 'idea'


### PR DESCRIPTION
When trying to use Kudens in a multiplatform build i got the following error
`Uncaught Error: Error loading module 'kudens'. Its dependency 'kotlin' was not found. Please, check whether 'kotlin' is loaded prior to 'kudens'.`
Similar to the this discussion: https://github.com/Kotlin/kotlin-frontend-plugin/issues/71
The discussion also suggested changing the `moduleKind` to fix the problem

Found that setting `moduleKind = "umd"` in kudens fixes the issue with the 'org.jetbrains.kotlin.multiplatform' plugin and also still works with the 'kotlin-platform-js' plugin
